### PR TITLE
feat: better flex align for html

### DIFF
--- a/Output/html.py
+++ b/Output/html.py
@@ -24,17 +24,17 @@ class Html(OutputProcessor):
 
         .course-container {
                 display: flex;
-                flex-wrap: wrap;
-                justify-content: space-between;
+                flex-flow: row wrap;
+                justify-content: space-around;
             }
 
         .course-card {
-                width: 45%;
+                flex-grow: 1;
                 background-color: #f5f5f5;
                 padding: 20px;
                 border-radius: 10px;
                 box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-                margin-bottom: 20px;
+                margin: 1rem;
             }
 
         .course-card div {


### PR DESCRIPTION
Before:
![af57ec9fcbaf325ab90e6d93c014c0d](https://github.com/user-attachments/assets/e9e12e7a-94e0-4739-8eda-878978a9f1bc)
After:
![image](https://github.com/user-attachments/assets/828076ee-65c2-4a55-af2f-4564e2356de0)
Make full use of screen space.